### PR TITLE
Update style.css to change leaderboard best diff value color from green to orange

### DIFF
--- a/webui/public/css/style.css
+++ b/webui/public/css/style.css
@@ -1695,7 +1695,7 @@ body {
 }
 
 .leaderboard-table .diff-cell {
-    color: #00d26a;
+    color: #ff931c;
     font-weight: 700;
 }
 


### PR DESCRIPTION
The current green is the same as the green status color and briefly makes you think that the miner is online. Changed to the same orange used for diff ranking numbers.